### PR TITLE
fix windows update

### DIFF
--- a/proc_master.go
+++ b/proc_master.go
@@ -13,13 +13,14 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"sync"
 	"syscall"
 	"time"
 )
 
-var tmpBinPath = filepath.Join(os.TempDir(), "overseer-"+token())
+var tmpBinPath = filepath.Join(os.TempDir(), "overseer-"+token()+extension())
 
 //a overseer master process
 type master struct {
@@ -425,4 +426,13 @@ func token() string {
 	buff := make([]byte, 8)
 	rand.Read(buff)
 	return hex.EncodeToString(buff)
+}
+
+// On Windows, include the .exe extension, noop otherwise.
+func extension() string {
+	if runtime.GOOS == "windows" {
+		return ".exe"
+	}
+
+	return ""
 }


### PR DESCRIPTION
The tmpBinPath did not have the .exe extension on Windows which would cause the update to fail because Windows only considers files that correlate with the PATHEXT variable and that does not include no extension files.

Closes #55 