### PR TITLE
fix 'sanity check failed' error

### DIFF
--- a/proc_master.go
+++ b/proc_master.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -288,7 +289,10 @@ func (mp *master) fetch() {
 		mp.warnf("failed to run temp binary: %s (%s) output \"%s\"", err, tmpBinPath, tokenOut)
 		return
 	}
-	if tokenIn != string(tokenOut) {
+	tokenOutStr := string(tokenOut)
+	tokenOutStrs := strings.Split(tokenOutStr, "\n")
+	tokenOutNew := tokenOutStrs[len(tokenOutStrs)-1]
+	if tokenIn != tokenOutNew {
 		mp.warnf("sanity check failed")
 		return
 	}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17827421/132488721-df4dd7b5-3512-4f12-ac98-7fd1f9b2d45e.png)
With or without output, the tokenOut can be correctly obtained.