### PR TITLE
bump go1.18, lint and http client

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,16 +4,16 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.12.x, 1.13.x, 1.14.x]
+        go-version: [1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Install Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build
         run: go build -v .
       - name: Test

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ tmp
 myapp*
 example/docker
 .idea
+.vscode

--- a/example/main.go
+++ b/example/main.go
@@ -14,8 +14,8 @@ import (
 // BuildID is compile-time variable
 var BuildID = "0"
 
-//convert your 'main()' into a 'prog(state)'
-//'prog()' is run in a child process
+// convert your 'main()' into a 'prog(state)'
+// 'prog()' is run in a child process
 func prog(state overseer.State) {
 	fmt.Printf("app#%s (%s) listening...\n", BuildID, state.ID)
 	http.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -27,8 +27,8 @@ func prog(state overseer.State) {
 	fmt.Printf("app#%s (%s) exiting...\n", BuildID, state.ID)
 }
 
-//then create another 'main' which runs the upgrades
-//'main()' is run in the initial process
+// then create another 'main' which runs the upgrades
+// 'main()' is run in the initial process
 func main() {
 	overseer.Run(overseer.Config{
 		Program: prog,

--- a/fetcher/fetcher_file.go
+++ b/fetcher/fetcher_file.go
@@ -23,7 +23,7 @@ type File struct {
 // Init sets the Path and Interval options
 func (f *File) Init() error {
 	if f.Path == "" {
-		return fmt.Errorf("Path required")
+		return errors.New("path required")
 	}
 	if f.Interval < 1*time.Second {
 		f.Interval = 1 * time.Second
@@ -88,12 +88,12 @@ func (f *File) updateHash() error {
 		if os.IsNotExist(err) {
 			return nil
 		}
-		return fmt.Errorf("Open file error: %s", err)
+		return fmt.Errorf("open file error: %w", err)
 	}
 	defer file.Close()
 	s, err := file.Stat()
 	if err != nil {
-		return fmt.Errorf("Get file stat error: %s", err)
+		return fmt.Errorf("get file stat error: %w", err)
 	}
 	f.hash = fmt.Sprintf("%d|%d", s.ModTime().UnixNano(), s.Size())
 	return nil

--- a/fetcher/fetcher_github.go
+++ b/fetcher/fetcher_github.go
@@ -12,10 +12,10 @@ import (
 	"time"
 )
 
-//Github uses the Github V3 API to retrieve the latest release
-//of a given repository and enumerate its assets. If a release
-//contains a matching asset, it will fetch
-//and return its io.Reader stream.
+// Github uses the Github V3 API to retrieve the latest release
+// of a given repository and enumerate its assets. If a release
+// contains a matching asset, it will fetch
+// and return its io.Reader stream.
 type Github struct {
 	//Github username and repository name
 	User, Repo string
@@ -46,10 +46,10 @@ func (h *Github) defaultAsset(filename string) bool {
 func (h *Github) Init() error {
 	//apply defaults
 	if h.User == "" {
-		return fmt.Errorf("User required")
+		return fmt.Errorf("user required")
 	}
 	if h.Repo == "" {
-		return fmt.Errorf("Repo required")
+		return fmt.Errorf("repo required")
 	}
 	if h.Asset == nil {
 		h.Asset = h.defaultAsset

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
 module github.com/jpillora/overseer
 
-go 1.13
+go 1.18
 
 require (
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d
-	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/jpillora/s3 v1.1.4
 )
+
+require github.com/go-ole/go-ole v1.2.4 // indirect

--- a/graceful.go
+++ b/graceful.go
@@ -18,7 +18,7 @@ func newOverseerListener(l net.Listener) *overseerListener {
 	}
 }
 
-//gracefully closing net.Listener
+// gracefully closing net.Listener
 type overseerListener struct {
 	net.Listener
 	closeError   error
@@ -51,7 +51,7 @@ func (l *overseerListener) Accept() (net.Conn, error) {
 	return uconn, nil
 }
 
-//non-blocking trigger close
+// non-blocking trigger close
 func (l *overseerListener) release(timeout time.Duration) {
 	//stop accepting connections - release fd
 	l.closeError = l.Listener.Close()
@@ -71,7 +71,7 @@ func (l *overseerListener) release(timeout time.Duration) {
 	}()
 }
 
-//blocking wait for close
+// blocking wait for close
 func (l *overseerListener) Close() error {
 	l.wg.Wait()
 	return l.closeError
@@ -84,7 +84,7 @@ func (l *overseerListener) File() *os.File {
 	return fl
 }
 
-//notifying on close net.Conn
+// notifying on close net.Conn
 type overseerConn struct {
 	net.Conn
 	wg     *sync.WaitGroup

--- a/overseer.go
+++ b/overseer.go
@@ -86,15 +86,15 @@ func validate(c *Config) error {
 	return nil
 }
 
-//RunErr allows manual handling of any
-//overseer errors.
+// RunErr allows manual handling of any
+// overseer errors.
 func RunErr(c Config) error {
 	return runErr(&c)
 }
 
-//Run executes overseer, if an error is
-//encountered, overseer fallsback to running
-//the program directly (unless Required is set).
+// Run executes overseer, if an error is
+// encountered, overseer fallsback to running
+// the program directly (unless Required is set).
 func Run(c Config) {
 	err := runErr(&c)
 	if err != nil {
@@ -109,7 +109,7 @@ func Run(c Config) {
 	os.Exit(0)
 }
 
-//sanityCheck returns true if a check was performed
+// sanityCheck returns true if a check was performed
 func sanityCheck() bool {
 	//sanity check
 	if token := os.Getenv(envBinCheck); token != "" {
@@ -124,19 +124,19 @@ func sanityCheck() bool {
 	return false
 }
 
-//SanityCheck manually runs the check to ensure this binary
-//is compatible with overseer. This tries to ensure that a restart
-//is never performed against a bad binary, as it would require
-//manual intervention to rectify. This is automatically done
-//on overseer.Run() though it can be manually run prior whenever
-//necessary.
+// SanityCheck manually runs the check to ensure this binary
+// is compatible with overseer. This tries to ensure that a restart
+// is never performed against a bad binary, as it would require
+// manual intervention to rectify. This is automatically done
+// on overseer.Run() though it can be manually run prior whenever
+// necessary.
 func SanityCheck() {
 	if sanityCheck() {
 		os.Exit(0)
 	}
 }
 
-//abstraction over master/slave
+// abstraction over master/slave
 var currentProcess interface {
 	triggerRestart()
 	run() error
@@ -162,15 +162,15 @@ func runErr(c *Config) error {
 	return currentProcess.run()
 }
 
-//Restart programmatically triggers a graceful restart. If NoRestart
-//is enabled, then this will essentially be a graceful shutdown.
+// Restart programmatically triggers a graceful restart. If NoRestart
+// is enabled, then this will essentially be a graceful shutdown.
 func Restart() {
 	if currentProcess != nil {
 		currentProcess.triggerRestart()
 	}
 }
 
-//IsSupported returns whether overseer is supported on the current OS.
+// IsSupported returns whether overseer is supported on the current OS.
 func IsSupported() bool {
 	return supported
 }

--- a/proc_slave.go
+++ b/proc_slave.go
@@ -103,7 +103,7 @@ func (sp *slave) initFileDescriptors() error {
 }
 
 func (sp *slave) watchSignal() {
-	signals := make(chan os.Signal)
+	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, sp.Config.RestartSignal)
 	go func() {
 		<-signals
@@ -142,12 +142,6 @@ func (sp *slave) triggerRestart() {
 
 func (sp *slave) debugf(f string, args ...interface{}) {
 	if sp.Config.Debug {
-		log.Printf("[overseer slave#"+sp.id+"] "+f, args...)
-	}
-}
-
-func (sp *slave) warnf(f string, args ...interface{}) {
-	if sp.Config.Debug || !sp.Config.NoWarn {
 		log.Printf("[overseer slave#"+sp.id+"] "+f, args...)
 	}
 }

--- a/proc_slave_others.go
+++ b/proc_slave_others.go
@@ -1,4 +1,4 @@
-// +build !windows
+//go:build !windows
 
 package overseer
 

--- a/proc_slave_windows.go
+++ b/proc_slave_windows.go
@@ -1,4 +1,4 @@
-// +build windows
+//go:build windows
 
 package overseer
 

--- a/sys_posix.go
+++ b/sys_posix.go
@@ -1,4 +1,4 @@
-// +build linux darwin freebsd
+//go:build linux || darwin || freebsd
 
 package overseer
 

--- a/sys_unsupported.go
+++ b/sys_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux,!darwin,!windows,!freebsd
+//go:build !linux && !darwin && !windows && !freebsd
 
 package overseer
 

--- a/sys_windows.go
+++ b/sys_windows.go
@@ -1,4 +1,4 @@
-// +build windows
+//go:build windows
 
 package overseer
 


### PR DESCRIPTION
- Bump minimum Go version to 1.18
- Addressing various linter warnings
- Using an initiated HTTP client with a default timeout