### PR TITLE
Do not capture stderr for sanity check

### DIFF
--- a/proc_master.go
+++ b/proc_master.go
@@ -282,7 +282,7 @@ func (mp *master) fetch() {
 			}
 		}
 	}()
-	tokenOut, err := cmd.CombinedOutput()
+	tokenOut, err := cmd.Output()
 	returned = true
 	if err != nil {
 		mp.warnf("failed to run temp binary: %s (%s) output \"%s\"", err, tmpBinPath, tokenOut)


### PR DESCRIPTION
sanity token is printed on stdout and can be safely read from stdout.
if a program outputs anything at stderr before invoking overseer, it can be discarded. 