### PR TITLE
Evaluate symlink if the process was called using that

### DIFF
--- a/proc_master.go
+++ b/proc_master.go
@@ -70,6 +70,10 @@ func (mp *master) checkBinary() error {
 	if err != nil {
 		return fmt.Errorf("failed to find binary path (%s)", err)
 	}
+	binPath, err = filepath.EvalSymlinks(binPath)
+	if err != nil {
+		return fmt.Errorf("failed to eval symlink (%s)", err)
+	}
 	mp.binPath = binPath
 	if info, err := os.Stat(binPath); err != nil {
 		return fmt.Errorf("failed to stat binary (%s)", err)


### PR DESCRIPTION
From https://pkg.go.dev/os#Executable
> if a symlink was used to start the process, depending on the operating system, the result might be the symlink or the path it pointed to. If a stable result is needed, path/filepath.EvalSymlinks might help