### PR TITLE
feat: Implement Windows-specific handling for socket management

### DIFF
--- a/proc_master.go
+++ b/proc_master.go
@@ -112,6 +112,12 @@ func (mp *master) setupSignalling() {
 			mp.handleSignal(s)
 		}
 	}()
+	
+	// On Windows, we need to periodically check for the temporary file
+	// that indicates the slave has released its sockets
+	if runtime.GOOS == "windows" {
+		go mp.checkSocketsReleasedOnWindows()
+	}
 }
 
 func (mp *master) handleSignal(s os.Signal) {
@@ -155,6 +161,15 @@ func (mp *master) sendSignal(s os.Signal) {
 
 func (mp *master) retreiveFileDescriptors() error {
 	mp.slaveExtraFiles = make([]*os.File, len(mp.Config.Addresses))
+	
+	// On Windows, we don't use file descriptors as they are not supported for TCP sockets
+	if runtime.GOOS == "windows" {
+		// Instead of using file descriptors, we'll save the addresses
+		// and let the slave process recreate the listeners
+		return nil
+	}
+	
+	// POSIX implementation (unchanged)
 	for i, addr := range mp.Config.Addresses {
 		a, err := net.ResolveTCPAddr("tcp", addr)
 		if err != nil {
@@ -354,15 +369,24 @@ func (mp *master) fork() error {
 	e = append(e, envBinPath+"="+mp.binPath)
 	e = append(e, envSlaveID+"="+strconv.Itoa(mp.slaveID))
 	e = append(e, envIsSlave+"=1")
-	e = append(e, envNumFDs+"="+strconv.Itoa(len(mp.slaveExtraFiles)))
+	
+	// Windows does not support passing file descriptors between processes
+	// So we'll pass 0 and use addresses directly in slave
+	if runtime.GOOS == "windows" {
+		e = append(e, envNumFDs+"=0")
+	} else {
+		e = append(e, envNumFDs+"="+strconv.Itoa(len(mp.slaveExtraFiles)))
+		//include socket files for non-Windows platforms
+		cmd.ExtraFiles = mp.slaveExtraFiles
+	}
+	
 	cmd.Env = e
 	//inherit master args/stdfiles
 	cmd.Args = os.Args
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	//include socket files
-	cmd.ExtraFiles = mp.slaveExtraFiles
+	
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("Failed to start slave process: %s", err)
 	}
@@ -435,4 +459,34 @@ func extension() string {
 	}
 
 	return ""
+}
+
+// checkSocketsReleasedOnWindows is a Windows-specific function that periodically
+// checks if the slave process has created a file indicating it has released its sockets
+func (mp *master) checkSocketsReleasedOnWindows() {
+	if runtime.GOOS != "windows" {
+		return
+	}
+	
+	for {
+		// Only check when we're actually waiting for a release
+		if !mp.awaitingUSR1 {
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		
+		// Check for the release file
+		tempFile := os.TempDir() + "/overseer-" + strconv.Itoa(mp.slaveID) + "-released"
+		if _, err := os.Stat(tempFile); err == nil {
+			// File exists, slave has released sockets
+			mp.debugf("windows: detected socket release via file")
+			mp.awaitingUSR1 = false
+			mp.descriptorsReleased <- true
+			
+			// Clean up the file
+			os.Remove(tempFile)
+		}
+		
+		time.Sleep(100 * time.Millisecond)
+	}
 }

--- a/proc_slave.go
+++ b/proc_slave.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"runtime"
 	"strconv"
 	"time"
 )
@@ -84,6 +85,13 @@ func (sp *slave) initFileDescriptors() error {
 	if err != nil {
 		return fmt.Errorf("invalid %s integer", envNumFDs)
 	}
+	
+	// On Windows, we create listeners directly instead of using file descriptors
+	if runtime.GOOS == "windows" {
+		return sp.initWindowsListeners()
+	}
+	
+	// POSIX file descriptor handling
 	sp.listeners = make([]*overseerListener, numFDs)
 	sp.state.Listeners = make([]net.Listener, numFDs)
 	for i := 0; i < numFDs; i++ {
@@ -99,6 +107,35 @@ func (sp *slave) initFileDescriptors() error {
 	if len(sp.state.Listeners) > 0 {
 		sp.state.Listener = sp.state.Listeners[0]
 	}
+	return nil
+}
+
+// initWindowsListeners creates listeners directly on Windows instead of using file descriptors
+func (sp *slave) initWindowsListeners() error {
+	sp.listeners = make([]*overseerListener, len(sp.Config.Addresses))
+	sp.state.Listeners = make([]net.Listener, len(sp.Config.Addresses))
+	
+	for i, addr := range sp.Config.Addresses {
+		a, err := net.ResolveTCPAddr("tcp", addr)
+		if err != nil {
+			return fmt.Errorf("Invalid address %s (%s)", addr, err)
+		}
+		
+		// Try to listen on the address
+		l, err := net.ListenTCP("tcp", a)
+		if err != nil {
+			return fmt.Errorf("Failed to listen on: %s (%s)", addr, err)
+		}
+		
+		u := newOverseerListener(l)
+		sp.listeners[i] = u
+		sp.state.Listeners[i] = u
+	}
+	
+	if len(sp.state.Listeners) > 0 {
+		sp.state.Listener = sp.state.Listeners[0]
+	}
+	
 	return nil
 }
 
@@ -121,7 +158,15 @@ func (sp *slave) watchSignal() {
 			//a new process before this child has actually exited.
 			//early restarts not supported with restarts disabled.
 			if !sp.NoRestart {
-				sp.masterProc.Signal(SIGUSR1)
+				// On Windows, we need to handle SIGUSR1 differently
+				if runtime.GOOS == "windows" {
+					// On Windows, use a different approach to signal the master
+					// Simply create a temporary file that the master can detect
+					sp.debugf("windows: signaling master that sockets are released")
+					sp.descriptorsReleased()
+				} else {
+					sp.masterProc.Signal(SIGUSR1)
+				}
 			}
 			//listeners should be waiting on connections to close...
 		}
@@ -132,6 +177,24 @@ func (sp *slave) watchSignal() {
 			os.Exit(1)
 		}()
 	}()
+}
+
+// descriptorsReleased is a Windows-specific function to inform the master process
+// that socket descriptors are released
+func (sp *slave) descriptorsReleased() {
+	if runtime.GOOS != "windows" {
+		return
+	}
+	
+	// On Windows, we can't use signals the same way as on POSIX systems
+	// So we'll create a temporary file to indicate the sockets are released
+	tempFile := os.TempDir() + "/overseer-" + sp.id + "-released"
+	f, err := os.Create(tempFile)
+	if err != nil {
+		sp.warnf("failed to create release file: %s", err)
+		return
+	}
+	f.Close()
 }
 
 func (sp *slave) triggerRestart() {


### PR DESCRIPTION
- Added periodic checking for socket release on Windows in proc_master.
- Updated file descriptor handling to create listeners directly in proc_slave for Windows.
- Introduced temporary file signaling mechanism for socket release notification on Windows.
- Ensured compatibility with non-Windows systems by maintaining existing POSIX logic.